### PR TITLE
fix: send test result when scenario is retried

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function (config) {
     //If test contains manual steps save status of each step
     event.dispatcher.on(event.step.finished, (step) => {
         //Check if actual test contains manual test integration and save each step status
-        if(!step.test?.file?.includes(`.feature`)) {
+        if (!step.test?.file?.includes(`.feature`)) {
             manual.save_steps_status(step, manual_steps_results);
         }
     });
@@ -64,14 +64,19 @@ module.exports = function (config) {
     //Get results after each test and push it to tests_results[]
     event.dispatcher.on(event.test.after, function (test) {
         recorder.add('Get test results', function () {
+            // Check if current test is a scenario retry
+            const is_retry_test = test?._retriedTest !== undefined;
+
             //Get test status
-            const status = test.state.toUpperCase();
+            const status = is_retry_test ? test._retriedTest.state.toUpperCase() : test.state.toUpperCase();
 
             let test_contains_examples = false;
             let test_contains_iterations = false;
 
             //Get tag from test, this tag will be used as a testKey in the api to link the test execution with a JIRA test (if createNewJiraTest is false)
-            test.tags.every(tag => {
+            const test_tags = is_retry_test ? test._retriedTest.tags : test.tags;
+
+            test_tags.every(tag => {
                 if (tag.toString().includes("@TEST_")) {
                     test_key = tag.split("@TEST_")[1];
                     return false;
@@ -82,13 +87,15 @@ module.exports = function (config) {
             });
 
             //Reset evidences array if test is neither manual with iterations nor bdd with examples
-            if(tests_results[tests_results.length - 1]?.test_key !== test_key){
+            if (tests_results[tests_results.length - 1]?.test_key !== test_key) {
                 test_evidences = [];
             }
 
             //Update comment array if test failed
             //Update evidences array if config.testExecutionSendEvidenceOnFail is true
-            if(test.state === "failed") {
+            const test_state = is_retry_test ? test._retriedTest.state : test.state;
+
+            if (test_state === "failed") {
                 test_comment.push(common.get_err_string(test));
                 if (config.testExecutionSendEvidenceOnFail) test_evidences.push(common.get_evidence_object(test));
             }
@@ -133,7 +140,7 @@ module.exports = function (config) {
             //Ignore codecept scenario and dont send its result to JIRA if its tag doesnt start with "@TEST_" and config.createNewJiraTest is false
             //But if @TEST_ tag doesnt exist and config.createNewJiraTest is true, testInfo object is added and Xray will try to create a new test in JIRA
             if (test_result.test_key === "no_xray_tag" && !config.createNewJiraTest) {
-                if(config.debug) output.print(`A test was ignored because its tag doesn\'t start with '@TEST_' and config option 'createNewJiraTest = false'`);
+                if (config.debug) output.print(`A test was ignored because its tag doesn\'t start with '@TEST_' and config option 'createNewJiraTest = false'`);
             } else {
                 tests_data.push(await data_generator.generate_tests_data({
                     testKey: test_result.test_key !== "no_xray_tag" ? test_result.test_key : null,
@@ -151,7 +158,7 @@ module.exports = function (config) {
                     steps: test_result.steps?.length !== 0 ? test_result.steps : null,
                     iterations: test_result.iterations?.length !== 0 ? test_result.iterations : null,
                     evidence: test_result.evidences,
-                    start : test_result.start,
+                    start: test_result.start,
                     finish: test_result.finish,
                     customFields: config.testExecutionCustomFields
                 }));
@@ -163,7 +170,7 @@ module.exports = function (config) {
             await data_generator.build_import_execution_data("existing_test_execution", config.existingTestExecutionKey, info_data, tests_data) :
             await data_generator.build_import_execution_data("new_test_execution", null, info_data, tests_data);
 
-        if(config.debug) output.print(`Send results to JIRA : \n${JSON.stringify(import_execution_data, null, 2)}`);
+        if (config.debug) output.print(`Send results to JIRA : \n${JSON.stringify(import_execution_data, null, 2)}`);
 
         //Validate XRAY execute import body before calling API
         xray_schema_checker.validate(import_execution_data);
@@ -172,7 +179,7 @@ module.exports = function (config) {
         const token = await xray_api.authenticate(config.xrayCloudUrl, config.xrayClientId, config.xraySecret, config.timeout);
         const response = await xray_api.execute_import(config.xrayCloudUrl, import_execution_data, token, config.timeout);
 
-        if(config.debug) output.print(`Response FROM XRAY API: \n${JSON.stringify(response.data, null, 2)}`);
-        if(response.status === 200) output.print(`\n> Tests results were sent to XRAY on TestExecution : ${response.data.key}\n`);
+        if (config.debug) output.print(`Response FROM XRAY API: \n${JSON.stringify(response.data, null, 2)}`);
+        if (response.status === 200) output.print(`\n> Tests results were sent to XRAY on TestExecution : ${response.data.key}\n`);
     });
 };

--- a/lib/bdd.js
+++ b/lib/bdd.js
@@ -6,25 +6,25 @@ module.exports = {
         const scenario = `Scenario: ${test.title}`;
         if (is_bdd) {
             //Check if it's a scenario outline with examples or a normal BDD scenario
-            if(bdd_examples.length !== 0 && tests_results[tests_results.length - 1].test_key === test_key){
-                bdd_examples.push(status);
+            if (bdd_examples.length !== 0 && tests_results[tests_results.length - 1].test_key === test_key) {
+                bdd_examples.push(status.toUpperCase());
                 test_contains_examples = true;
             } else {
                 bdd_examples = [];
                 test_comment = [];
                 test_evidences = [];
-                bdd_examples.push(status);
+                bdd_examples.push(status.toUpperCase());
             }
 
-            if(!test_contains_examples){
+            if (!test_contains_examples) {
                 test_evidences = [];
                 test_comment = [];
-                if(test.state === "failed") {
+                if (status === "failed") {
                     test_comment.push(common.get_err_string(test));
                     if (config.testExecutionSendEvidenceOnFail) test_evidences.push(common.get_evidence_object(test));
                 }
-                common.push_test_state_to_results(tests_results, test_key, test_comment, test_evidences, test, "Cucumber",null, scenario);
-            } else{
+                common.push_test_state_to_results(tests_results, test_key, test_comment, test_evidences, test, "Cucumber", null, scenario);
+            } else {
                 //If actual test is scenario outline then push examples array with its state to the actual result
                 tests_results[tests_results.length - 1].examples = bdd_examples;
                 tests_results[tests_results.length - 1].status = bdd_examples.includes("FAILED") ? "FAILED" : "PASSED";

--- a/lib/common.js
+++ b/lib/common.js
@@ -3,7 +3,13 @@ const fs = require('fs');
 
 module.exports = {
     push_test_state_to_results(tests_results, test_key, test_comment, test_evidences, test, test_type, test_info_steps = null, scenario = null) {
-        if (test.state === "passed") {
+        // Check if actual test have retries to push only the last result when it fails
+        const test_have_retries = test._retries !== -1;
+        const is_retry_test = test?._retriedTest !== undefined;
+        const is_last_retry = test?._retries === test?._currentRetry;
+        const test_state = is_retry_test ? test._retriedTest.state : test.state;
+
+        if (test_state === "passed") {
             tests_results.push({
                 title: test.title,
                 status: "PASSED",
@@ -11,13 +17,13 @@ module.exports = {
                 test_key: test_key,
                 start: moment(test.startedAt).format(),
                 finish: moment().format(),
-                id: test.id,
+                id: test?.uid,
                 evidences: [],
                 test_type: test_type,
                 test_info_steps: test_info_steps,
                 bdd_scenario: scenario
             });
-        } else {
+        } else if (test_state === "failed" && (test_have_retries && is_last_retry || !test_have_retries)) {
             tests_results.push({
                 title: test.title,
                 status: "FAILED",
@@ -25,7 +31,7 @@ module.exports = {
                 test_key: test_key,
                 start: moment(test.startedAt).format(),
                 finish: moment().format(),
-                id: test.id,
+                id: test?.uid,
                 evidences: test_evidences,
                 test_type: test_type,
                 test_info_steps: test_info_steps,
@@ -38,12 +44,17 @@ module.exports = {
         if (test.err?.template) {
             return `${test.err?.params?.customMessage}expected ${test.err?.params?.jar} ${test.err?.params?.type} '${test.err?.params?.needle}'`;
         } else {
-            return test.err.toString().replace(/\"/g, "").replace(/\'/g, "").replace(/\é/g, "e").replace(/\è/g, "e").replace(/\ê/g, "e").replace(/\à/g, "a").replace(/\ù/g, "u");
+            return test.err?.toString().replace(/\"/g, "").replace(/\'/g, "").replace(/\é/g, "e").replace(/\è/g, "e").replace(/\ê/g, "e").replace(/\à/g, "a").replace(/\ù/g, "u");
         }
     },
 
     get_evidence_object(test) {
-        const screenshot_file = test.artifacts?.screenshot;
+        // Check if current test is a scenario retry
+        const is_retry_test = test?._retriedTest !== undefined;
+        const test_artifacts = is_retry_test ? test._retriedTest.artifacts : test.artifacts;
+
+        // Get screenshot file name
+        const screenshot_file = test_artifacts.screenshot;
         const screenshot_encoded = this.base64_encode(screenshot_file);
         const screenshot_name = screenshot_file.split('/').pop();
 

--- a/lib/common.js
+++ b/lib/common.js
@@ -5,9 +5,8 @@ module.exports = {
     push_test_state_to_results(tests_results, test_key, test_comment, test_evidences, test, test_type, test_info_steps = null, scenario = null) {
         // Check if actual test have retries to push only the last result when it fails
         const test_have_retries = test._retries !== -1;
-        const is_retry_test = test?._retriedTest !== undefined;
         const is_last_retry = test?._retries === test?._currentRetry;
-        const test_state = is_retry_test ? test._retriedTest.state : test.state;
+        const test_state = this.get_test_state(test);
 
         if (test_state === "passed") {
             tests_results.push({
@@ -31,7 +30,7 @@ module.exports = {
                 test_key: test_key,
                 start: moment(test.startedAt).format(),
                 finish: moment().format(),
-                id: test?.uid,
+                id: test.id,
                 evidences: test_evidences,
                 test_type: test_type,
                 test_info_steps: test_info_steps,
@@ -50,8 +49,7 @@ module.exports = {
 
     get_evidence_object(test) {
         // Check if current test is a scenario retry
-        const is_retry_test = test?._retriedTest !== undefined;
-        const test_artifacts = is_retry_test ? test._retriedTest.artifacts : test.artifacts;
+        const test_artifacts = this.is_retry_test(test) ? test._retriedTest.artifacts : test.artifacts;
 
         // Get screenshot file name
         const screenshot_file = test_artifacts.screenshot;
@@ -68,5 +66,22 @@ module.exports = {
     base64_encode(file) {
         const image = fs.readFileSync(file);
         return new Buffer(image).toString('base64');
+    },
+
+    is_retry_test(test) {
+        // Check if current test is a scenario retry
+        return test?._retriedTest !== undefined;
+    },
+
+    get_test_tags(test) {
+        return this.is_retry_test(test) ? test._retriedTest.tags : test.tags;
+    },
+
+    get_test_state(test) {
+        if (this.is_retry_test(test) && test?._retriedTest?.state === undefined) {
+            return test.state
+        } else {
+            return this.is_retry_test(test) ? test._retriedTest.state : test.state;
+        }
     }
 };

--- a/lib/generic.js
+++ b/lib/generic.js
@@ -1,11 +1,11 @@
 const common = require('./common');
 
 module.exports = {
-    save_generic_results(is_generic, tests_results, test_key, test_comment, test_evidences, test, config) {
-        if(is_generic){
+    save_generic_results(is_generic, tests_results, test_key, test_comment, test_evidences, test, config, status) {
+        if (is_generic) {
             test_evidences = [];
             test_comment = [];
-            if(test.state === "failed") {
+            if (status === "failed") {
                 test_comment.push(common.get_err_string(test));
                 if (config.testExecutionSendEvidenceOnFail) test_evidences.push(common.get_evidence_object(test));
             }

--- a/lib/manual.js
+++ b/lib/manual.js
@@ -5,20 +5,20 @@ module.exports = {
     save_manual_results(is_manual, tests_results, manual_steps_results, iterations_array, manual_iteration, iteration_number, test_key, test_comment, test_evidences, test_contains_iterations, test, status, config) {
         const is_data_driven = test.inject?.current !== undefined;
         //If actual test contains Manual steps
-        if(is_manual){
+        if (is_manual) {
             //build array steps to be sent if user wants to create jira Manual test
             const test_info_steps = build_test_info_steps(manual_steps_results);
 
             if (is_data_driven) {
                 //Check if there is more than one iteration
-                if(manual_iteration.length !== {} && tests_results[tests_results.length - 1]?.test_key === test_key){
+                if (manual_iteration.length !== {} && tests_results[tests_results.length - 1]?.test_key === test_key) {
                     //If its not the first iteration
                     iteration_number++;
                     manual_iteration = {
                         name: `Iteration ${iteration_number}`,
                         parameters: build_xray_iterations_parameters_array(test),
-                        log: status.includes("FAILED") ? test_comment.toString() : "Iteration passed successfully",
-                        status: status,
+                        log: status.toUpperCase().includes("FAILED") ? test_comment.toString() : "Iteration passed successfully",
+                        status: status.toUpperCase(),
                         steps: manual_steps_results.length > 1 ? manual_steps_results.shift() && build_xray_steps_array(manual_steps_results) : []
                     };
 
@@ -33,25 +33,25 @@ module.exports = {
                     manual_iteration = {
                         name: `Iteration ${iteration_number}`,
                         parameters: build_xray_iterations_parameters_array(test),
-                        log: status.includes("FAILED") ? test_comment.toString() : "Iteration passed successfully",
-                        status: status,
+                        log: status.toUpperCase().includes("FAILED") ? test_comment.toString() : "Iteration passed successfully",
+                        status: status.toUpperCase(),
                         steps: manual_steps_results.length > 1 ? manual_steps_results.shift() && build_xray_steps_array(manual_steps_results) : []
                     };
                 }
-                manual_iteration.status = manual_iteration.steps !== [] && manual_iteration.steps.includes("FAILED") ? "FAILED" : status;
+                manual_iteration.status = manual_iteration.steps !== [] && manual_iteration.steps.includes("FAILED") ? "FAILED" : status.toUpperCase();
             }
 
-            if(!test_contains_iterations){
+            if (!test_contains_iterations) {
                 test_evidences = [];
                 test_comment = [];
-                if(test.state === "failed") {
+                if (status === "failed") {
                     test_comment.push(common.get_err_string(test));
                     if (config.testExecutionSendEvidenceOnFail) test_evidences.push(common.get_evidence_object(test));
                 }
                 common.push_test_state_to_results(tests_results, test_key, test_comment, test_evidences, test, "Manual", test_info_steps);
             }
 
-            if (!is_data_driven){
+            if (!is_data_driven) {
                 //will add steps to tests array because tests doesn't contain iterations
                 manual_steps_results.shift();
                 tests_results[tests_results.length - 1].steps = build_xray_steps_array(manual_steps_results);
@@ -64,7 +64,7 @@ module.exports = {
                 tests_results[tests_results.length - 1].evidences = JSON.stringify(iterations_array).includes("FAILED") ? test_evidences : [];
                 tests_results[tests_results.length - 1].finish = moment().format()
             }
-            manual_steps_results= [[]];
+            manual_steps_results = [[]];
         }
 
         return [manual_steps_results, iterations_array, iteration_number, test_comment, test_evidences];
@@ -73,10 +73,10 @@ module.exports = {
     //Save steps results
     save_steps_status(step, manual_steps_results) {
         if (step.metaStep?.actor !== undefined) {
-            if (manual_steps_results[manual_steps_results.length - 1][0]?.step === step.metaStep?.actor && manual_steps_results[manual_steps_results.length - 1][0]?.step !== undefined){
-                manual_steps_results[manual_steps_results.length - 1].push({step: step.metaStep?.actor, name: `${step.name}(${step.args})`, status: step.status});
+            if (manual_steps_results[manual_steps_results.length - 1][0]?.step === step.metaStep?.actor && manual_steps_results[manual_steps_results.length - 1][0]?.step !== undefined) {
+                manual_steps_results[manual_steps_results.length - 1].push({ step: step.metaStep?.actor, name: `${step.name}(${step.args})`, status: step.status });
             } else {
-                manual_steps_results.push([{step: step.metaStep?.actor, name: `${step.name}(${step.args})`, status: step.status}]);
+                manual_steps_results.push([{ step: step.metaStep?.actor, name: `${step.name}(${step.args})`, status: step.status }]);
             }
         }
     }
@@ -140,10 +140,10 @@ function build_xray_iterations_parameters_array(test) {
     let parameters = [];
 
     for (const param in test.inject.current) {
-        if (param !== 'toString'){
+        if (param !== 'toString') {
             parameters.push({
-                name : param,
-                value : test.inject.current[param]
+                name: param,
+                value: test.inject.current[param]
             })
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -37,6 +37,7 @@ It allows you to:
 - Link the "Test Execution" to a specific test plan
 - Enter all fields of the "Test Execution"
 - Send data to the "custom fields" of the Test Run
+- Send the last result of a scenario if it retries one or more times after a fail
 
 ## Configuration
 Choose between the following two options: **"Quickstart"** ou **"Manual configuration"**.


### PR DESCRIPTION
Fixes https://github.com/saadichouaib/codeceptjs-xray-cloud-helper/issues/7

### Context

Actually, when a test is retried, codeceptjs returns a different `test` object.

For instance, to get the status of a test we use `test.state`, but when test is a retry we should get it through `test._retriedTest.state`.

This PR fixes this issue so only the last result of a retried scenario is sent to Xray.